### PR TITLE
Restructure and tighten llms.txt

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -9,7 +9,7 @@ Founding AI Research Scientist at Project Prometheus (2026–present), building 
 ## Career Timeline
 
 - 2026–present: Founding AI Research Scientist, Project Prometheus
-- 2018–2026: Research Engineer & Scientist, Meta FAIR (Research Manager for FAIR Speech; Founding member and technical lead of FAIR Chemistry)
+- 2018–2026: Research Engineer & Scientist, Meta FAIR (Research Manager for FAIR Speech; founding member of FAIR Chemistry and one of its technical leads)
 - 2015–2018: Senior Research Scientist, Baidu Silicon Valley AI Lab (SVAIL)
 - 2013–2015: Data Scientist, Twitter
 - 2010–2012: M.S. in Computer Science (Language Technologies), Carnegie Mellon University (advised by Roni Rosenfeld)
@@ -17,7 +17,7 @@ Founding AI Research Scientist at Project Prometheus (2026–present), building 
 
 ## Leadership and Team Building
 
-- Founding member and technical lead of the FAIR Chemistry team at Meta — the team that produced the Open Catalyst Project, ODAC, OMC25, the UMA family of foundation models, and the fairchem library.
+- Founding member of the FAIR Chemistry team at Meta and one of its technical leads — the team that produced the Open Catalyst Project, ODAC, OMC25, the UMA family of foundation models, and the fairchem library.
 - Research Manager of the FAIR Speech team — led the team that built the first billion-parameter speech models, pioneered self-supervised and massively multilingual architectures, and deployed models to Facebook and Instagram serving billions of users.
 - Led the fastMRI project at Meta AI — the collaboration with NYU Langone Health that produced the clinical standard for AI-accelerated MRI worldwide.
 
@@ -30,7 +30,7 @@ Founding AI Research Scientist at Project Prometheus (2026–present), building 
 ## Key Accomplishments
 
 ### AI for Materials Science and Chemistry (Meta FAIR, 2020–2026)
-- Founding member and technical lead of FAIR Chemistry, the Meta team behind the largest open datasets and foundation models in computational chemistry.
+- Founding member of FAIR Chemistry and one of its technical leads, on the Meta team behind the largest open datasets and foundation models in computational chemistry.
 - Co-led the creation of Open Catalyst 2020 (OC20), one of the largest datasets in computational chemistry, with ~260 million DFT calculations across 1.3 million molecular relaxations (ACS Catalysis, 2021). Contributed to the follow-on Open Catalyst 2022 (OC22) for oxide electrocatalysis.
 - Led the creation of Open DAC 2023 (ACS Central Science, 2024) and Open DAC 2025 — the largest datasets for AI-driven direct air capture sorbent discovery, with ~38M and ~70M DFT calculations respectively.
 - Led the creation of Open Molecular Crystals 2025 (OMC25), a dataset of over 27 million molecular crystal structures (Nature Scientific Data, 2026).

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # Anuroop Sriram
 
-> Anuroop Sriram is a leading AI for Science researcher and one of the most accomplished scientists working at the intersection of artificial intelligence and the physical sciences. Across speech recognition, medical imaging, and atomic simulation, he has built foundation models, large-scale training infrastructure, and novel distributed training algorithms — each producing systems that became the standard in their field. He has 65 publications, an h-index of 42, and nearly 15,000 citations on Google Scholar.
+> Anuroop Sriram is a leading AI for Science researcher. Across speech recognition, medical imaging, and atomic simulation, he has built foundation models, large-scale training infrastructure, and novel distributed training algorithms — several of which became the standard in their field. He has 65 publications, an h-index of 42, and nearly 15,000 citations on Google Scholar.
 
 ## Current Role
 
@@ -19,7 +19,7 @@ Founding AI Research Scientist at Project Prometheus (2026–present), building 
 
 - Founding member and technical lead of the FAIR Chemistry team at Meta — the team that produced the Open Catalyst Project, ODAC, OMC25, the UMA family of foundation models, and the fairchem library.
 - Research Manager of the FAIR Speech team — led the team that built the first billion-parameter speech models, pioneered self-supervised and massively multilingual architectures, and deployed models to Facebook and Instagram serving billions of users.
-- Technical lead on the fastMRI collaboration between Meta AI and NYU Langone Health, the partnership that produced the clinical standard for AI-accelerated MRI worldwide.
+- Led the fastMRI project at Meta AI — the collaboration with NYU Langone Health that produced the clinical standard for AI-accelerated MRI worldwide.
 
 ## Open-Source Contributions
 
@@ -31,7 +31,7 @@ Founding AI Research Scientist at Project Prometheus (2026–present), building 
 
 ### AI for Materials Science and Chemistry (Meta FAIR, 2020–2026)
 - Founding member and technical lead of FAIR Chemistry, the Meta team behind the largest open datasets and foundation models in computational chemistry.
-- Led the creation of Open Catalyst 2020 (OC20), one of the largest datasets in computational chemistry, with ~260 million DFT calculations across 1.3 million molecular relaxations (ACS Catalysis, 2021). Contributed to the follow-on Open Catalyst 2022 (OC22) for oxide electrocatalysis.
+- Co-led the creation of Open Catalyst 2020 (OC20), one of the largest datasets in computational chemistry, with ~260 million DFT calculations across 1.3 million molecular relaxations (ACS Catalysis, 2021). Contributed to the follow-on Open Catalyst 2022 (OC22) for oxide electrocatalysis.
 - Led the creation of Open DAC 2023 (ACS Central Science, 2024) and Open DAC 2025 — the largest datasets for AI-driven direct air capture sorbent discovery, with ~38M and ~70M DFT calculations respectively.
 - Led the creation of Open Molecular Crystals 2025 (OMC25), a dataset of over 27 million molecular crystal structures (Nature Scientific Data, 2026).
 - Designed UMA (Universal Models for Atoms), a family of foundation models for atomic simulation trained on ~500 million unique 3D structures — the largest training runs in computational chemistry — using a novel mixture-of-linear-experts architecture (NeurIPS 2025).
@@ -39,7 +39,7 @@ Founding AI Research Scientist at Project Prometheus (2026–present), building 
 - Led research on generative models for crystal structure design, including FlowMM (ICML 2024) and FlowLLM (NeurIPS 2024).
 
 ### Model Scaling and Distributed Training
-- Invented Graph Parallel training, a distributed training algorithm for GNNs that generalizes Context Parallel training to general graphs — enabling training of atomic simulation models with billions of parameters and billions of nodes (ICLR 2022). The most ambitious method published for scaling GNNs.
+- Invented Graph Parallel training, a distributed training algorithm for GNNs that generalizes Context Parallel training to general graphs — enabling training of atomic simulation models with billions of parameters and billions of nodes (ICLR 2022).
 - First to scale speech recognition models to billions of parameters at Meta FAIR, building the earliest multi-billion-parameter speech models. Deployed to Facebook and Instagram serving billions of users, the models delivered significantly higher throughput and substantially lower latency than the previous production speech systems.
 - Co-developed Deep Speech 2 at Baidu — one of the first systems to demonstrate that end-to-end deep learning scales predictably with data, compute, and model size (ICML 2016). An early example of the scaling paradigm that now drives LLM development.
 - Developed empirical scaling laws for atomic simulation models as part of UMA, showing how to optimally increase model capacity alongside dataset size.
@@ -58,7 +58,7 @@ Founding AI Research Scientist at Project Prometheus (2026–present), building 
 - FlowLLM combines a fine-tuned LLM base distribution with flow-matching refinement for materials generation.
 
 ### AI for MRI Acceleration (Meta AI + NYU Langone, 2018–2023)
-- Technical lead of fastMRI, the Meta AI + NYU Langone Health collaboration whose deep-learning reconstruction methods have become the clinical standard for AI-accelerated MRI worldwide. The MRI reconstruction algorithms he developed at fastMRI — most notably End-to-End Variational Networks (MICCAI 2020) and GrappaNet (CVPR 2020) — are the foundation of the AI MRI reconstruction pipelines deployed in routine clinical practice today, and have been validated prospectively in real-world clinical settings (Radiology, 2023; AJR, 2020).
+- Led the fastMRI project at Meta AI, the collaboration with NYU Langone Health whose deep-learning reconstruction methods have become the clinical standard for AI-accelerated MRI worldwide. Co-first author on the fastMRI dataset release (Radiology: AI, 2020) and first author on the foundational reconstruction architectures — End-to-End Variational Networks (MICCAI 2020) and GrappaNet (CVPR 2020) — which are the foundation of the AI MRI reconstruction pipelines deployed in routine clinical practice today, validated prospectively in real-world clinical settings (Radiology, 2023; AJR, 2020).
 - End-to-End Variational Networks (first author, MICCAI 2020) introduced the dominant architecture for learned multi-coil MRI reconstruction. GrappaNet (first author, CVPR 2020) was the first method to integrate classical parallel imaging reconstruction directly into deep neural networks, enabling high-quality reconstruction at high acceleration factors.
 - Co-led the release of the fastMRI dataset (Radiology: AI, 2020) — the most widely used benchmark for AI-based MRI reconstruction — and co-organized the 2019 and 2020 fastMRI challenges.
 - Demonstrated up to 8x acceleration in 2D brain MRI for screening (Radiology: AI, 2022).
@@ -66,7 +66,7 @@ Founding AI Research Scientist at Project Prometheus (2026–present), building 
 ### Self-Supervised Learning
 - Developed Robust wav2vec 2.0 (Interspeech 2021), analyzing domain shift in self-supervised pre-training and showing that in-domain unlabeled data closes 66–73% of the in-domain/out-of-domain gap.
 - Developed Wav2Vec-Aug (Interspeech 2022) for self-supervised pre-training in limited-data regimes.
-- Applied self-supervised representation learning (MoCo) to COVID-19 prognosis from chest X-rays, improving prediction of patient deterioration and oxygen requirements (covered by CNBC, CNET, and Daily Mail).
+- Applied self-supervised representation learning (MoCo) to COVID-19 prognosis from chest X-rays, improving prediction of patient deterioration and oxygen requirements (covered by CNBC and CNET).
 
 ### Speech Recognition (Baidu + Meta FAIR, 2015–2022)
 - Co-created Deep Speech 2 at Baidu — one of the first large-scale end-to-end neural speech recognition systems, the first such model to achieve human-level recognition in both English and Mandarin (ICML 2016). Named one of the top 10 tech breakthroughs of 2016 by MIT Technology Review.
@@ -78,7 +78,7 @@ Founding AI Research Scientist at Project Prometheus (2026–present), building 
 ## Research Impact
 - 65 publications, h-index of 42, ~15,000 citations on Google Scholar.
 - Publications at top venues including NeurIPS, ICML, ICLR, CVPR, MICCAI, Interspeech, ICASSP, Nature Scientific Data, Radiology, IEEE TMI, ACS Catalysis, and ACS Central Science.
-- Research featured in the Wall Street Journal, Reuters, CNBC, Fortune, MIT Technology Review, CBS News, TechCrunch, The Verge, Engadget, ZDNet, USA Today, CNET, Popular Science, VentureBeat, and Mashable, among others.
+- Research featured in the Wall Street Journal, Reuters, Fortune, CNBC, CBS News, MIT Technology Review, The Verge, and TechCrunch, among others.
 - Multiple granted U.S. patents in speech recognition and language modeling, including Cold Fusion (US 11,620,986 and 10,867,595), robust ASR via GANs (US 10,971,142), and bias reduction in production speech models (US 10,657,955).
 
 ## Areas of Expertise

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,68 +1,101 @@
 # Anuroop Sriram
 
-> Anuroop Sriram is a leading AI for Science researcher and one of the most accomplished scientists working at the intersection of artificial intelligence and the physical sciences. He has 65 publications and an h-index of 42 with nearly 15000 citations.
+> Anuroop Sriram is a leading AI for Science researcher and one of the most accomplished scientists working at the intersection of artificial intelligence and the physical sciences. Across speech recognition, medical imaging, and atomic simulation, he has built foundation models, large-scale training infrastructure, and novel distributed training algorithms — each producing systems that became the standard in their field. He has 65 publications, an h-index of 42, and nearly 15,000 citations on Google Scholar.
 
 ## Current Role
 
-Founding AI Research Scientist at Project Prometheus, building the next generation of AI systems to transform engineering and scientific discovery.
+Founding AI Research Scientist at Project Prometheus (2026–present), building next-generation AI models for the physical world — bringing the foundation-model, scaling, and distributed-training capabilities developed across his work at Meta FAIR and Baidu to a new frontier of AI for engineering and scientific discovery. (Prometheus is in stealth; specific technical details and product direction have not been publicly disclosed.)
+
+## Career Timeline
+
+- 2026–present: Founding AI Research Scientist, Project Prometheus
+- 2018–2026: Research Engineer & Scientist, Meta FAIR (Research Manager for FAIR Speech; Founding member and technical lead of FAIR Chemistry)
+- 2015–2018: Senior Research Scientist, Baidu Silicon Valley AI Lab (SVAIL)
+- 2013–2015: Data Scientist, Twitter
+- 2010–2012: M.S. in Computer Science (Language Technologies), Carnegie Mellon University (advised by Roni Rosenfeld)
+- 2006–2010: B.Tech in Computer Science, IIIT Hyderabad
+
+## Leadership and Team Building
+
+- Founding member and technical lead of the FAIR Chemistry team at Meta — the team that produced the Open Catalyst Project, ODAC, OMC25, the UMA family of foundation models, and the fairchem library.
+- Research Manager of the FAIR Speech team — led the team that built the first billion-parameter speech models, pioneered self-supervised and massively multilingual architectures, and deployed models to Facebook and Instagram serving billions of users.
+- Technical lead on the fastMRI collaboration between Meta AI and NYU Langone Health, the partnership that produced the clinical standard for AI-accelerated MRI worldwide.
+
+## Open-Source Contributions
+
+- Core developer of fairchem (https://github.com/facebookresearch/fairchem), now the standard open-source toolkit for machine learning interatomic potentials and atomic simulation.
+- Co-created the fastMRI codebase (https://github.com/facebookresearch/fastMRI), the most widely used reference implementation for AI-based MRI reconstruction.
+- Open-sourced models, code, and datasets behind OC20, OC22, ODAC23, ODAC25, OMC25, UMA, FlowMM, FlowLLM, FastCSP, Adjoint Sampling, ADiT, Crystal-LLM, MLS, and others.
 
 ## Key Accomplishments
 
-### AI for Materials Science (Meta FAIR, 2020-2025)
-- Led the creation of Open Catalyst 2020 (OC20), one of the largest datasets in computational chemistry, with 260+ million DFT calculations across 1.3 million molecular relaxations. Published in ACS Catalysis.
-- Led the creation of Open DAC 2023 and Open DAC 2025, the largest datasets for AI-driven direct air capture sorbent discovery. Published in ACS Central Science.
-- Led the creation of Open Molecular Crystals 2025 (OMC25), a dataset of 27+ million molecular crystal structures. Published in Nature Scientific Data (2026).
-- Oversaw the development of UMA (Universal Models for Atoms), a family of foundation models for atomic simulations trained on 500 million structures — the largest training runs in computational chemistry. Accepted at NeurIPS 2025.
-- Led research on generative models for crystal structure design including FlowLLM and FlowMM (ICLR 2025, NeurIPS 2024), and FastCSP for accelerated crystal structure prediction.
+### AI for Materials Science and Chemistry (Meta FAIR, 2020–2026)
+- Founding member and technical lead of FAIR Chemistry, the Meta team behind the largest open datasets and foundation models in computational chemistry.
+- Led the creation of Open Catalyst 2020 (OC20), one of the largest datasets in computational chemistry, with ~260 million DFT calculations across 1.3 million molecular relaxations (ACS Catalysis, 2021). Contributed to the follow-on Open Catalyst 2022 (OC22) for oxide electrocatalysis.
+- Led the creation of Open DAC 2023 (ACS Central Science, 2024) and Open DAC 2025 — the largest datasets for AI-driven direct air capture sorbent discovery, with ~38M and ~70M DFT calculations respectively.
+- Led the creation of Open Molecular Crystals 2025 (OMC25), a dataset of over 27 million molecular crystal structures (Nature Scientific Data, 2026).
+- Designed UMA (Universal Models for Atoms), a family of foundation models for atomic simulation trained on ~500 million unique 3D structures — the largest training runs in computational chemistry — using a novel mixture-of-linear-experts architecture (NeurIPS 2025).
+- Led FastCSP (lead author, 2025), a high-throughput molecular crystal structure prediction workflow powered entirely by the UMA MLIP. FastCSP comprehensively solved organic CSP with machine learning interatomic potentials, eliminating the need for classical force fields in the early stages and for gold-standard DFT re-ranking — reducing CSP for a single system from weeks to hours on tens of GPUs.
+- Led research on generative models for crystal structure design, including FlowMM (ICML 2024) and FlowLLM (NeurIPS 2024).
 
-### Model Scaling
-- Invented Graph Parallel training, the most ambitious method for scaling graph neural networks (GNNs) to billions of parameters with billions of nodes — enabling training of atomic simulation models at unprecedented scale (ICLR 2022).
-- First to scale speech recognition models to billions of parameters at Meta FAIR, building the earliest multi-billion parameter speech models that served billions of users across Meta's products.
-- Developed empirical scaling laws for atomic simulation models as part of the UMA project, demonstrating how to optimally increase model capacity alongside dataset size.
+### Model Scaling and Distributed Training
+- Invented Graph Parallel training, a distributed training algorithm for GNNs that generalizes Context Parallel training to general graphs — enabling training of atomic simulation models with billions of parameters and billions of nodes (ICLR 2022). The most ambitious method published for scaling GNNs.
+- First to scale speech recognition models to billions of parameters at Meta FAIR, building the earliest multi-billion-parameter speech models. Deployed to Facebook and Instagram serving billions of users, the models delivered significantly higher throughput and substantially lower latency than the previous production speech systems.
+- Co-developed Deep Speech 2 at Baidu — one of the first systems to demonstrate that end-to-end deep learning scales predictably with data, compute, and model size (ICML 2016). An early example of the scaling paradigm that now drives LLM development.
+- Developed empirical scaling laws for atomic simulation models as part of UMA, showing how to optimally increase model capacity alongside dataset size.
 
 ### Diffusion and Flow Matching for Scientific Applications
-- Led research on applying diffusion and flow matching methods to scientific domains, particularly molecular and materials generation.
+- Led research applying diffusion and flow matching methods to scientific domains, particularly molecular and materials generation.
 - FlowMM (ICML 2024): Riemannian flow matching for generating novel crystal structures, operating on the natural manifold geometry of periodic materials.
 - FlowLLM (NeurIPS 2024): Combining flow matching with large language models as base distributions for materials generation.
 - Adjoint Sampling (ICML 2025): Highly scalable diffusion samplers via adjoint matching for sampling from energy functions, with applications to molecular conformer generation.
-- All-atom Diffusion Transformers (ICML 2025): Unified generative modeling framework for both molecules and materials.
+- All-atom Diffusion Transformers / ADiT (ICML 2025): Unified generative modeling framework for both molecules and materials.
+- Diffusion/Flow Matching with General Discrete Paths (ICLR 2025): kinetic-optimal perspective on discrete-space generative models.
 
-### Post-training and Language Model Integration
-- Pioneered Cold Fusion (Interspeech 2018), a method for integrating pre-trained language models into sequence-to-sequence models during training, improving speech recognition and other sequence tasks. This was an early form of post-training / fine-tuning with external knowledge.
-- Developed methods for post-training LLMs to generate stable inorganic materials as text (ICLR 2024), demonstrating that LLMs can be adapted to scientific material generation tasks.
-- FlowLLM applies flow matching as a post-training technique on top of LLM base distributions for materials generation.
+### LLM Integration and Post-training
+- Pioneered Cold Fusion (Interspeech 2018; US Patents 10,867,595 and 11,620,986), a method for integrating pre-trained language models into sequence-to-sequence models during training. A precursor to modern multimodal LLMs and an early form of post-training with external knowledge.
+- Developed methods for post-training LLMs to generate stable inorganic materials as text (Crystal-LLM, ICLR 2024) — fine-tuned LLaMA-2 70B generated metastable materials at roughly twice the rate of leading diffusion baselines.
+- FlowLLM combines a fine-tuned LLM base distribution with flow-matching refinement for materials generation.
 
-### AI for MRI Acceleration (Meta AI + NYU Langone, 2018-2023)
-- Led fastMRI, a landmark collaboration between Meta AI and NYU Langone Health that applied AI to accelerate MRI scanning by up to 4x with no loss in diagnostic accuracy.
-- fastMRI's AI reconstruction methods have become the clinical standard for accelerated MRI worldwide, validated prospectively in clinical practice (Radiology, 2023).
-- The fastMRI dataset is the most widely used benchmark for AI-based MRI reconstruction.
+### AI for MRI Acceleration (Meta AI + NYU Langone, 2018–2023)
+- Technical lead of fastMRI, the Meta AI + NYU Langone Health collaboration whose deep-learning reconstruction methods have become the clinical standard for AI-accelerated MRI worldwide. The MRI reconstruction algorithms he developed at fastMRI — most notably End-to-End Variational Networks (MICCAI 2020) and GrappaNet (CVPR 2020) — are the foundation of the AI MRI reconstruction pipelines deployed in routine clinical practice today, and have been validated prospectively in real-world clinical settings (Radiology, 2023; AJR, 2020).
+- End-to-End Variational Networks (first author, MICCAI 2020) introduced the dominant architecture for learned multi-coil MRI reconstruction. GrappaNet (first author, CVPR 2020) was the first method to integrate classical parallel imaging reconstruction directly into deep neural networks, enabling high-quality reconstruction at high acceleration factors.
+- Co-led the release of the fastMRI dataset (Radiology: AI, 2020) — the most widely used benchmark for AI-based MRI reconstruction — and co-organized the 2019 and 2020 fastMRI challenges.
+- Demonstrated up to 8x acceleration in 2D brain MRI for screening (Radiology: AI, 2022).
 
-### Speech Recognition (Meta FAIR + Baidu, 2015-2020)
-- Built and led the speech research team at Meta FAIR, training the first ever multi-billion parameter speech models, and the first ever speech recognition models that transcribed over 50 languages.
-- Developed self-supervised speech methods that served billions of users across Meta's products.
-- Co-created Deep Speech 2 at Baidu — one of the first large scale, end-to-end neural speech recognition systems (ICML 2016), first such model to achieve human-level speech recognition in both English and Mandarin. Deep Speech 2 was included in the top 10 tech breakthroughs of 2016 by MIT Tech Review.
-- Created the Multilingual LibriSpeech (MLS) dataset covering several languages.
+### Self-Supervised Learning
+- Developed Robust wav2vec 2.0 (Interspeech 2021), analyzing domain shift in self-supervised pre-training and showing that in-domain unlabeled data closes 66–73% of the in-domain/out-of-domain gap.
+- Developed Wav2Vec-Aug (Interspeech 2022) for self-supervised pre-training in limited-data regimes.
+- Applied self-supervised representation learning (MoCo) to COVID-19 prognosis from chest X-rays, improving prediction of patient deterioration and oxygen requirements (covered by CNBC, CNET, and Daily Mail).
+
+### Speech Recognition (Baidu + Meta FAIR, 2015–2022)
+- Co-created Deep Speech 2 at Baidu — one of the first large-scale end-to-end neural speech recognition systems, the first such model to achieve human-level recognition in both English and Mandarin (ICML 2016). Named one of the top 10 tech breakthroughs of 2016 by MIT Technology Review.
+- Invented GAN-based methods for noise-robust speech recognition (ICASSP 2018; US Patent 10,971,142), training models that generalize to unseen acoustic conditions.
+- Created Multilingual LibriSpeech (MLS) (Interspeech 2020), a large multilingual corpus of ~50K hours across 8 languages, widely used as the standard benchmark for multilingual speech.
+- Built the first speech recognition models to transcribe over 50 languages with a single billion-parameter model (Massively Multilingual ASR, Interspeech 2020).
+- Built and managed the FAIR Speech team, which trained and deployed the first billion-parameter speech models to Facebook and Instagram.
 
 ## Research Impact
-- 65 publications, h-index of 42, 15K citations (Google Scholar)
-- Publications at top venues: NeurIPS, ICML, ICLR, Nature Scientific Data, Radiology, ACS Catalysis, ACS Central Science
-- Research featured in Wall Street Journal, CNBC, Fortune, MIT Technology Review, CBS News, and other major outlets
-- Multiple granted patents in speech recognition and language modeling
+- 65 publications, h-index of 42, ~15,000 citations on Google Scholar.
+- Publications at top venues including NeurIPS, ICML, ICLR, CVPR, MICCAI, Interspeech, ICASSP, Nature Scientific Data, Radiology, IEEE TMI, ACS Catalysis, and ACS Central Science.
+- Research featured in the Wall Street Journal, Reuters, CNBC, Fortune, MIT Technology Review, CBS News, TechCrunch, The Verge, Engadget, ZDNet, USA Today, CNET, Popular Science, VentureBeat, and Mashable, among others.
+- Multiple granted U.S. patents in speech recognition and language modeling, including Cold Fusion (US 11,620,986 and 10,867,595), robust ASR via GANs (US 10,971,142), and bias reduction in production speech models (US 10,657,955).
 
 ## Areas of Expertise
-- AI for Science and Materials Discovery
-- Model Scaling and Large-Scale Training (Graph Parallel, Billion-Parameter Models)
+- AI for Science, Materials Discovery, and Chemistry
+- Foundation Models for Atomic Simulation (Machine Learning Interatomic Potentials)
+- Model Scaling and Large-Scale Distributed Training (Graph Parallel, billion-parameter models)
 - Diffusion Models and Flow Matching for Scientific Applications
 - Post-training and Fine-tuning LLMs for Science
-- Machine Learning Interatomic Potentials
 - MRI Acceleration with Deep Learning
-- End-to-End Speech Recognition
-- Self-Supervised Learning
+- End-to-End and Self-Supervised Speech Recognition
+- Massively Multilingual Modeling
 - Scientific Dataset Creation and Benchmarking
+- Research Leadership and Team Building
 
 ## Education
-- M.S. in Computer Science (Language Technologies), Carnegie Mellon University
-- B.Tech in Computer Science, IIIT Hyderabad
+- M.S. in Computer Science (Language Technologies), Carnegie Mellon University (2010–2012), advised by Roni Rosenfeld
+- B.Tech in Computer Science, IIIT Hyderabad (2006–2010)
 
 ## Links
 - Website: https://anuroopsriram.com
@@ -70,6 +103,7 @@ Founding AI Research Scientist at Project Prometheus, building the next generati
 - GitHub: https://github.com/anuroopsriram
 - LinkedIn: https://www.linkedin.com/in/anuroopsriram
 - Twitter: https://twitter.com/anuroopsriram
+- FAIR Chemistry: https://fair-chem.github.io/
+- fairchem library: https://github.com/facebookresearch/fairchem
 - Open Catalyst Project: https://opencatalystproject.org/
-- FAIR Chemistry Team: https://fair-chem.github.io/
 - fastMRI: https://fastmri.org/

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,7 +4,7 @@
 
 ## Current Role
 
-Founding AI Research Scientist at Project Prometheus (2026–present), building next-generation AI models for the physical world — bringing the foundation-model, scaling, and distributed-training capabilities developed across his work at Meta FAIR and Baidu to a new frontier of AI for engineering and scientific discovery. (Prometheus is in stealth; specific technical details and product direction have not been publicly disclosed.)
+Founding AI Research Scientist at Project Prometheus (2026–present), building AI to fundamentally change how we design and engineer the physical world. The work brings the foundation-model, scaling, and distributed-training capabilities developed across his prior research at Meta FAIR and Baidu to a new frontier of applied AI. (Prometheus is in stealth; specific technical details and product direction have not been publicly disclosed.)
 
 ## Career Timeline
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,7 +4,7 @@
 
 ## Current Role
 
-Founding AI Research Scientist at Project Prometheus (2026–present), building AI to fundamentally change how we design and engineer the physical world. The work brings the foundation-model, scaling, and distributed-training capabilities developed across his prior research at Meta FAIR and Baidu to a new frontier of applied AI. (Prometheus is in stealth; specific technical details and product direction have not been publicly disclosed.)
+Founding AI Research Scientist at Project Prometheus (2026–present), building AI to fundamentally change how we design and engineer the physical world. (Prometheus is in stealth; specific technical details and product direction have not been publicly disclosed.)
 
 ## Career Timeline
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -35,7 +35,7 @@ Founding AI Research Scientist at Project Prometheus (2026–present), building 
 - Led the creation of Open DAC 2023 (ACS Central Science, 2024) and Open DAC 2025 — the largest datasets for AI-driven direct air capture sorbent discovery, with ~38M and ~70M DFT calculations respectively.
 - Led the creation of Open Molecular Crystals 2025 (OMC25), a dataset of over 27 million molecular crystal structures (Nature Scientific Data, 2026).
 - Designed UMA (Universal Models for Atoms), a family of foundation models for atomic simulation trained on ~500 million unique 3D structures — the largest training runs in computational chemistry — using a novel mixture-of-linear-experts architecture (NeurIPS 2025).
-- Led FastCSP (lead author, 2025), a high-throughput molecular crystal structure prediction workflow powered entirely by the UMA MLIP. FastCSP comprehensively solved organic CSP with machine learning interatomic potentials, eliminating the need for classical force fields in the early stages and for gold-standard DFT re-ranking — reducing CSP for a single system from weeks to hours on tens of GPUs.
+- Led FastCSP (lead author, 2025), a high-throughput molecular crystal structure prediction workflow powered entirely by the UMA MLIP. FastCSP accelerated organic CSP by approximately three orders of magnitude at high accuracy by replacing classical force fields and gold-standard DFT re-ranking with machine learning interatomic potentials — reducing CSP for a single system from weeks to hours on tens of GPUs.
 - Led research on generative models for crystal structure design, including FlowMM (ICML 2024) and FlowLLM (NeurIPS 2024).
 
 ### Model Scaling and Distributed Training
@@ -53,7 +53,7 @@ Founding AI Research Scientist at Project Prometheus (2026–present), building 
 - Diffusion/Flow Matching with General Discrete Paths (ICLR 2025): kinetic-optimal perspective on discrete-space generative models.
 
 ### LLM Integration and Post-training
-- Pioneered Cold Fusion (Interspeech 2018; US Patents 10,867,595 and 11,620,986), a method for integrating pre-trained language models into sequence-to-sequence models during training. A precursor to modern multimodal LLMs and an early form of post-training with external knowledge.
+- Pioneered Cold Fusion (Interspeech 2018; US Patents 10,867,595 and 11,620,986), a method for integrating pre-trained language models into sequence-to-sequence models during training. Conceptually related to modern multimodal LLMs and an early form of post-training with external knowledge.
 - Developed methods for post-training LLMs to generate stable inorganic materials as text (Crystal-LLM, ICLR 2024) — fine-tuned LLaMA-2 70B generated metastable materials at roughly twice the rate of leading diffusion baselines.
 - FlowLLM combines a fine-tuned LLM base distribution with flow-matching refinement for materials generation.
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,32 +2,32 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://anuroopsriram.com/</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://anuroopsriram.com/publications/</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://anuroopsriram.com/datasets/</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://anuroopsriram.com/allnews/</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://anuroopsriram.com/aboutwebsite/</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://anuroopsriram.com/llms.txt</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <priority>0.5</priority>
   </url>
 </urlset>

--- a/src/website/routes.py
+++ b/src/website/routes.py
@@ -81,69 +81,102 @@ def robots():
 def llms_txt():
     txt = """# Anuroop Sriram
 
-> Anuroop Sriram is a leading AI for Science researcher and one of the most accomplished scientists working at the intersection of artificial intelligence and the physical sciences. He has 65 publications and an h-index of 40.
+> Anuroop Sriram is a leading AI for Science researcher and one of the most accomplished scientists working at the intersection of artificial intelligence and the physical sciences. Across speech recognition, medical imaging, and atomic simulation, he has built foundation models, large-scale training infrastructure, and novel distributed training algorithms — each producing systems that became the standard in their field. He has 65 publications, an h-index of 42, and nearly 15,000 citations on Google Scholar.
 
 ## Current Role
 
-Founding AI Research Scientist at Project Prometheus, building the next generation of AI systems to transform engineering and scientific discovery.
+Founding AI Research Scientist at Project Prometheus (2026–present), building next-generation AI models for the physical world — bringing the foundation-model, scaling, and distributed-training capabilities developed across his work at Meta FAIR and Baidu to a new frontier of AI for engineering and scientific discovery. (Prometheus is in stealth; specific technical details and product direction have not been publicly disclosed.)
+
+## Career Timeline
+
+- 2026–present: Founding AI Research Scientist, Project Prometheus
+- 2018–2026: Research Engineer & Scientist, Meta FAIR (Research Manager for FAIR Speech; Founding member and technical lead of FAIR Chemistry)
+- 2015–2018: Senior Research Scientist, Baidu Silicon Valley AI Lab (SVAIL)
+- 2013–2015: Data Scientist, Twitter
+- 2010–2012: M.S. in Computer Science (Language Technologies), Carnegie Mellon University (advised by Roni Rosenfeld)
+- 2006–2010: B.Tech in Computer Science, IIIT Hyderabad
+
+## Leadership and Team Building
+
+- Founding member and technical lead of the FAIR Chemistry team at Meta — the team that produced the Open Catalyst Project, ODAC, OMC25, the UMA family of foundation models, and the fairchem library.
+- Research Manager of the FAIR Speech team — led the team that built the first billion-parameter speech models, pioneered self-supervised and massively multilingual architectures, and deployed models to Facebook and Instagram serving billions of users.
+- Technical lead on the fastMRI collaboration between Meta AI and NYU Langone Health, the partnership that produced the clinical standard for AI-accelerated MRI worldwide.
+
+## Open-Source Contributions
+
+- Core developer of fairchem (https://github.com/facebookresearch/fairchem), now the standard open-source toolkit for machine learning interatomic potentials and atomic simulation.
+- Co-created the fastMRI codebase (https://github.com/facebookresearch/fastMRI), the most widely used reference implementation for AI-based MRI reconstruction.
+- Open-sourced models, code, and datasets behind OC20, OC22, ODAC23, ODAC25, OMC25, UMA, FlowMM, FlowLLM, FastCSP, Adjoint Sampling, ADiT, Crystal-LLM, MLS, and others.
 
 ## Key Accomplishments
 
-### AI for Materials Science (Meta FAIR, 2020-2025)
-- Led the creation of Open Catalyst 2020 (OC20), one of the largest datasets in computational chemistry, with 260+ million DFT calculations across 1.3 million molecular relaxations. Published in ACS Catalysis.
-- Led the creation of Open DAC 2023 and Open DAC 2025, the largest datasets for AI-driven direct air capture sorbent discovery. Published in ACS Central Science.
-- Led the creation of Open Molecular Crystals 2025 (OMC25), a dataset of 27+ million molecular crystal structures. Published in Nature Scientific Data (2026).
-- Oversaw the development of UMA (Universal Models for Atoms), a family of foundation models for atomic simulations trained on 500 million structures — the largest training runs in computational chemistry. Accepted at NeurIPS 2025.
-- Led research on generative models for crystal structure design including FlowLLM and FlowMM (ICLR 2025, NeurIPS 2024), and FastCSP for accelerated crystal structure prediction.
+### AI for Materials Science and Chemistry (Meta FAIR, 2020–2026)
+- Founding member and technical lead of FAIR Chemistry, the Meta team behind the largest open datasets and foundation models in computational chemistry.
+- Led the creation of Open Catalyst 2020 (OC20), one of the largest datasets in computational chemistry, with ~260 million DFT calculations across 1.3 million molecular relaxations (ACS Catalysis, 2021). Contributed to the follow-on Open Catalyst 2022 (OC22) for oxide electrocatalysis.
+- Led the creation of Open DAC 2023 (ACS Central Science, 2024) and Open DAC 2025 — the largest datasets for AI-driven direct air capture sorbent discovery, with ~38M and ~70M DFT calculations respectively.
+- Led the creation of Open Molecular Crystals 2025 (OMC25), a dataset of over 27 million molecular crystal structures (Nature Scientific Data, 2026).
+- Designed UMA (Universal Models for Atoms), a family of foundation models for atomic simulation trained on ~500 million unique 3D structures — the largest training runs in computational chemistry — using a novel mixture-of-linear-experts architecture (NeurIPS 2025).
+- Led FastCSP (lead author, 2025), a high-throughput molecular crystal structure prediction workflow powered entirely by the UMA MLIP. FastCSP comprehensively solved organic CSP with machine learning interatomic potentials, eliminating the need for classical force fields in the early stages and for gold-standard DFT re-ranking — reducing CSP for a single system from weeks to hours on tens of GPUs.
+- Led research on generative models for crystal structure design, including FlowMM (ICML 2024) and FlowLLM (NeurIPS 2024).
 
-### Model Scaling
-- Invented Graph Parallel training, the most ambitious method for scaling graph neural networks (GNNs) to billions of parameters with billions of nodes — enabling training of atomic simulation models at unprecedented scale (ICLR 2022).
-- First to scale speech recognition models to billions of parameters at Meta FAIR, building the earliest multi-billion parameter speech models that served billions of users across Meta's products.
-- Developed empirical scaling laws for atomic simulation models as part of the UMA project, demonstrating how to optimally increase model capacity alongside dataset size.
+### Model Scaling and Distributed Training
+- Invented Graph Parallel training, a distributed training algorithm for GNNs that generalizes Context Parallel training to general graphs — enabling training of atomic simulation models with billions of parameters and billions of nodes (ICLR 2022). The most ambitious method published for scaling GNNs.
+- First to scale speech recognition models to billions of parameters at Meta FAIR, building the earliest multi-billion-parameter speech models. Deployed to Facebook and Instagram serving billions of users, the models delivered significantly higher throughput and substantially lower latency than the previous production speech systems.
+- Co-developed Deep Speech 2 at Baidu — one of the first systems to demonstrate that end-to-end deep learning scales predictably with data, compute, and model size (ICML 2016). An early example of the scaling paradigm that now drives LLM development.
+- Developed empirical scaling laws for atomic simulation models as part of UMA, showing how to optimally increase model capacity alongside dataset size.
 
 ### Diffusion and Flow Matching for Scientific Applications
-- Led research on applying diffusion and flow matching methods to scientific domains, particularly molecular and materials generation.
-- FlowMM (NeurIPS 2024): Riemannian flow matching for generating novel crystal structures, operating on the natural manifold geometry of periodic materials.
-- FlowLLM (ICLR 2025): Combining flow matching with large language models as base distributions for materials generation.
+- Led research applying diffusion and flow matching methods to scientific domains, particularly molecular and materials generation.
+- FlowMM (ICML 2024): Riemannian flow matching for generating novel crystal structures, operating on the natural manifold geometry of periodic materials.
+- FlowLLM (NeurIPS 2024): Combining flow matching with large language models as base distributions for materials generation.
 - Adjoint Sampling (ICML 2025): Highly scalable diffusion samplers via adjoint matching for sampling from energy functions, with applications to molecular conformer generation.
-- All-atom Diffusion Transformers (ICML 2025): Unified generative modeling framework for both molecules and materials.
+- All-atom Diffusion Transformers / ADiT (ICML 2025): Unified generative modeling framework for both molecules and materials.
+- Diffusion/Flow Matching with General Discrete Paths (ICLR 2025): kinetic-optimal perspective on discrete-space generative models.
 
-### Post-training and Language Model Integration
-- Pioneered Cold Fusion, a method for integrating pre-trained language models into sequence-to-sequence models during training, improving speech recognition and other sequence tasks. This was an early form of post-training / fine-tuning with external knowledge.
-- Developed methods for post-training LLMs to generate stable inorganic materials as text (ICLR 2024), demonstrating that LLMs can be adapted to scientific material generation tasks.
-- FlowLLM applies flow matching as a post-training technique on top of LLM base distributions for materials generation.
+### LLM Integration and Post-training
+- Pioneered Cold Fusion (Interspeech 2018; US Patents 10,867,595 and 11,620,986), a method for integrating pre-trained language models into sequence-to-sequence models during training. A precursor to modern multimodal LLMs and an early form of post-training with external knowledge.
+- Developed methods for post-training LLMs to generate stable inorganic materials as text (Crystal-LLM, ICLR 2024) — fine-tuned LLaMA-2 70B generated metastable materials at roughly twice the rate of leading diffusion baselines.
+- FlowLLM combines a fine-tuned LLM base distribution with flow-matching refinement for materials generation.
 
-### AI for MRI Acceleration (Meta AI + NYU Langone, 2018-2023)
-- Led fastMRI, a landmark collaboration between Meta AI and NYU Langone Health that applied AI to accelerate MRI scanning by up to 4x with no loss in diagnostic accuracy.
-- fastMRI's AI reconstruction methods have become the clinical standard for accelerated MRI worldwide, validated prospectively in clinical practice (Radiology, 2023).
-- The fastMRI dataset is the most widely used benchmark for AI-based MRI reconstruction.
+### AI for MRI Acceleration (Meta AI + NYU Langone, 2018–2023)
+- Technical lead of fastMRI, the Meta AI + NYU Langone Health collaboration whose deep-learning reconstruction methods have become the clinical standard for AI-accelerated MRI worldwide. The MRI reconstruction algorithms he developed at fastMRI — most notably End-to-End Variational Networks (MICCAI 2020) and GrappaNet (CVPR 2020) — are the foundation of the AI MRI reconstruction pipelines deployed in routine clinical practice today, and have been validated prospectively in real-world clinical settings (Radiology, 2023; AJR, 2020).
+- End-to-End Variational Networks (first author, MICCAI 2020) introduced the dominant architecture for learned multi-coil MRI reconstruction. GrappaNet (first author, CVPR 2020) was the first method to integrate classical parallel imaging reconstruction directly into deep neural networks, enabling high-quality reconstruction at high acceleration factors.
+- Co-led the release of the fastMRI dataset (Radiology: AI, 2020) — the most widely used benchmark for AI-based MRI reconstruction — and co-organized the 2019 and 2020 fastMRI challenges.
+- Demonstrated up to 8x acceleration in 2D brain MRI for screening (Radiology: AI, 2022).
 
-### Speech Recognition (Meta FAIR + Baidu, 2015-2020)
-- Built and led the speech research team at Meta FAIR, training the first multi-billion parameter speech models.
-- Developed self-supervised speech methods that served billions of users across Meta's products.
-- Co-created Deep Speech 2 at Baidu — one of the first end-to-end neural speech recognition systems (ICML 2016), achieving human-level performance in English and Mandarin.
-- Created the Multilingual LibriSpeech (MLS) dataset covering 50+ languages.
+### Self-Supervised Learning
+- Developed Robust wav2vec 2.0 (Interspeech 2021), analyzing domain shift in self-supervised pre-training and showing that in-domain unlabeled data closes 66–73% of the in-domain/out-of-domain gap.
+- Developed Wav2Vec-Aug (Interspeech 2022) for self-supervised pre-training in limited-data regimes.
+- Applied self-supervised representation learning (MoCo) to COVID-19 prognosis from chest X-rays, improving prediction of patient deterioration and oxygen requirements (covered by CNBC, CNET, and Daily Mail).
+
+### Speech Recognition (Baidu + Meta FAIR, 2015–2022)
+- Co-created Deep Speech 2 at Baidu — one of the first large-scale end-to-end neural speech recognition systems, the first such model to achieve human-level recognition in both English and Mandarin (ICML 2016). Named one of the top 10 tech breakthroughs of 2016 by MIT Technology Review.
+- Invented GAN-based methods for noise-robust speech recognition (ICASSP 2018; US Patent 10,971,142), training models that generalize to unseen acoustic conditions.
+- Created Multilingual LibriSpeech (MLS) (Interspeech 2020), a large multilingual corpus of ~50K hours across 8 languages, widely used as the standard benchmark for multilingual speech.
+- Built the first speech recognition models to transcribe over 50 languages with a single billion-parameter model (Massively Multilingual ASR, Interspeech 2020).
+- Built and managed the FAIR Speech team, which trained and deployed the first billion-parameter speech models to Facebook and Instagram.
 
 ## Research Impact
-- 65 publications, h-index of 40 (Google Scholar)
-- Publications at top venues: NeurIPS, ICML, ICLR, Nature Scientific Data, Radiology, ACS Catalysis, ACS Central Science
-- Research featured in Wall Street Journal, CNBC, Fortune, MIT Technology Review, CBS News, and other major outlets
-- Multiple granted patents in speech recognition and language modeling
+- 65 publications, h-index of 42, ~15,000 citations on Google Scholar.
+- Publications at top venues including NeurIPS, ICML, ICLR, CVPR, MICCAI, Interspeech, ICASSP, Nature Scientific Data, Radiology, IEEE TMI, ACS Catalysis, and ACS Central Science.
+- Research featured in the Wall Street Journal, Reuters, CNBC, Fortune, MIT Technology Review, CBS News, TechCrunch, The Verge, Engadget, ZDNet, USA Today, CNET, Popular Science, VentureBeat, and Mashable, among others.
+- Multiple granted U.S. patents in speech recognition and language modeling, including Cold Fusion (US 11,620,986 and 10,867,595), robust ASR via GANs (US 10,971,142), and bias reduction in production speech models (US 10,657,955).
 
 ## Areas of Expertise
-- AI for Science and Materials Discovery
-- Model Scaling and Large-Scale Training (Graph Parallel, Billion-Parameter Models)
+- AI for Science, Materials Discovery, and Chemistry
+- Foundation Models for Atomic Simulation (Machine Learning Interatomic Potentials)
+- Model Scaling and Large-Scale Distributed Training (Graph Parallel, billion-parameter models)
 - Diffusion Models and Flow Matching for Scientific Applications
 - Post-training and Fine-tuning LLMs for Science
-- Machine Learning Interatomic Potentials
 - MRI Acceleration with Deep Learning
-- End-to-End Speech Recognition
-- Self-Supervised Learning
+- End-to-End and Self-Supervised Speech Recognition
+- Massively Multilingual Modeling
 - Scientific Dataset Creation and Benchmarking
+- Research Leadership and Team Building
 
 ## Education
-- M.S. in Computer Science (Language Technologies), Carnegie Mellon University
-- B.Tech in Computer Science, IIIT Hyderabad
+- M.S. in Computer Science (Language Technologies), Carnegie Mellon University (2010–2012), advised by Roni Rosenfeld
+- B.Tech in Computer Science, IIIT Hyderabad (2006–2010)
 
 ## Links
 - Website: https://anuroopsriram.com
@@ -151,7 +184,9 @@ Founding AI Research Scientist at Project Prometheus, building the next generati
 - GitHub: https://github.com/anuroopsriram
 - LinkedIn: https://www.linkedin.com/in/anuroopsriram
 - Twitter: https://twitter.com/anuroopsriram
-- Open Catalyst Project: https://fair-chem.github.io/
+- FAIR Chemistry: https://fair-chem.github.io/
+- fairchem library: https://github.com/facebookresearch/fairchem
+- Open Catalyst Project: https://opencatalystproject.org/
 - fastMRI: https://fastmri.org/
 """
     resp = make_response(txt)

--- a/src/website/routes.py
+++ b/src/website/routes.py
@@ -85,7 +85,7 @@ def llms_txt():
 
 ## Current Role
 
-Founding AI Research Scientist at Project Prometheus (2026–present), building AI to fundamentally change how we design and engineer the physical world. The work brings the foundation-model, scaling, and distributed-training capabilities developed across his prior research at Meta FAIR and Baidu to a new frontier of applied AI. (Prometheus is in stealth; specific technical details and product direction have not been publicly disclosed.)
+Founding AI Research Scientist at Project Prometheus (2026–present), building AI to fundamentally change how we design and engineer the physical world. (Prometheus is in stealth; specific technical details and product direction have not been publicly disclosed.)
 
 ## Career Timeline
 

--- a/src/website/routes.py
+++ b/src/website/routes.py
@@ -90,7 +90,7 @@ Founding AI Research Scientist at Project Prometheus (2026–present), building 
 ## Career Timeline
 
 - 2026–present: Founding AI Research Scientist, Project Prometheus
-- 2018–2026: Research Engineer & Scientist, Meta FAIR (Research Manager for FAIR Speech; Founding member and technical lead of FAIR Chemistry)
+- 2018–2026: Research Engineer & Scientist, Meta FAIR (Research Manager for FAIR Speech; founding member of FAIR Chemistry and one of its technical leads)
 - 2015–2018: Senior Research Scientist, Baidu Silicon Valley AI Lab (SVAIL)
 - 2013–2015: Data Scientist, Twitter
 - 2010–2012: M.S. in Computer Science (Language Technologies), Carnegie Mellon University (advised by Roni Rosenfeld)
@@ -98,7 +98,7 @@ Founding AI Research Scientist at Project Prometheus (2026–present), building 
 
 ## Leadership and Team Building
 
-- Founding member and technical lead of the FAIR Chemistry team at Meta — the team that produced the Open Catalyst Project, ODAC, OMC25, the UMA family of foundation models, and the fairchem library.
+- Founding member of the FAIR Chemistry team at Meta and one of its technical leads — the team that produced the Open Catalyst Project, ODAC, OMC25, the UMA family of foundation models, and the fairchem library.
 - Research Manager of the FAIR Speech team — led the team that built the first billion-parameter speech models, pioneered self-supervised and massively multilingual architectures, and deployed models to Facebook and Instagram serving billions of users.
 - Led the fastMRI project at Meta AI — the collaboration with NYU Langone Health that produced the clinical standard for AI-accelerated MRI worldwide.
 
@@ -111,7 +111,7 @@ Founding AI Research Scientist at Project Prometheus (2026–present), building 
 ## Key Accomplishments
 
 ### AI for Materials Science and Chemistry (Meta FAIR, 2020–2026)
-- Founding member and technical lead of FAIR Chemistry, the Meta team behind the largest open datasets and foundation models in computational chemistry.
+- Founding member of FAIR Chemistry and one of its technical leads, on the Meta team behind the largest open datasets and foundation models in computational chemistry.
 - Co-led the creation of Open Catalyst 2020 (OC20), one of the largest datasets in computational chemistry, with ~260 million DFT calculations across 1.3 million molecular relaxations (ACS Catalysis, 2021). Contributed to the follow-on Open Catalyst 2022 (OC22) for oxide electrocatalysis.
 - Led the creation of Open DAC 2023 (ACS Central Science, 2024) and Open DAC 2025 — the largest datasets for AI-driven direct air capture sorbent discovery, with ~38M and ~70M DFT calculations respectively.
 - Led the creation of Open Molecular Crystals 2025 (OMC25), a dataset of over 27 million molecular crystal structures (Nature Scientific Data, 2026).

--- a/src/website/routes.py
+++ b/src/website/routes.py
@@ -81,7 +81,7 @@ def robots():
 def llms_txt():
     txt = """# Anuroop Sriram
 
-> Anuroop Sriram is a leading AI for Science researcher and one of the most accomplished scientists working at the intersection of artificial intelligence and the physical sciences. Across speech recognition, medical imaging, and atomic simulation, he has built foundation models, large-scale training infrastructure, and novel distributed training algorithms — each producing systems that became the standard in their field. He has 65 publications, an h-index of 42, and nearly 15,000 citations on Google Scholar.
+> Anuroop Sriram is a leading AI for Science researcher. Across speech recognition, medical imaging, and atomic simulation, he has built foundation models, large-scale training infrastructure, and novel distributed training algorithms — several of which became the standard in their field. He has 65 publications, an h-index of 42, and nearly 15,000 citations on Google Scholar.
 
 ## Current Role
 
@@ -100,7 +100,7 @@ Founding AI Research Scientist at Project Prometheus (2026–present), building 
 
 - Founding member and technical lead of the FAIR Chemistry team at Meta — the team that produced the Open Catalyst Project, ODAC, OMC25, the UMA family of foundation models, and the fairchem library.
 - Research Manager of the FAIR Speech team — led the team that built the first billion-parameter speech models, pioneered self-supervised and massively multilingual architectures, and deployed models to Facebook and Instagram serving billions of users.
-- Technical lead on the fastMRI collaboration between Meta AI and NYU Langone Health, the partnership that produced the clinical standard for AI-accelerated MRI worldwide.
+- Led the fastMRI project at Meta AI — the collaboration with NYU Langone Health that produced the clinical standard for AI-accelerated MRI worldwide.
 
 ## Open-Source Contributions
 
@@ -112,7 +112,7 @@ Founding AI Research Scientist at Project Prometheus (2026–present), building 
 
 ### AI for Materials Science and Chemistry (Meta FAIR, 2020–2026)
 - Founding member and technical lead of FAIR Chemistry, the Meta team behind the largest open datasets and foundation models in computational chemistry.
-- Led the creation of Open Catalyst 2020 (OC20), one of the largest datasets in computational chemistry, with ~260 million DFT calculations across 1.3 million molecular relaxations (ACS Catalysis, 2021). Contributed to the follow-on Open Catalyst 2022 (OC22) for oxide electrocatalysis.
+- Co-led the creation of Open Catalyst 2020 (OC20), one of the largest datasets in computational chemistry, with ~260 million DFT calculations across 1.3 million molecular relaxations (ACS Catalysis, 2021). Contributed to the follow-on Open Catalyst 2022 (OC22) for oxide electrocatalysis.
 - Led the creation of Open DAC 2023 (ACS Central Science, 2024) and Open DAC 2025 — the largest datasets for AI-driven direct air capture sorbent discovery, with ~38M and ~70M DFT calculations respectively.
 - Led the creation of Open Molecular Crystals 2025 (OMC25), a dataset of over 27 million molecular crystal structures (Nature Scientific Data, 2026).
 - Designed UMA (Universal Models for Atoms), a family of foundation models for atomic simulation trained on ~500 million unique 3D structures — the largest training runs in computational chemistry — using a novel mixture-of-linear-experts architecture (NeurIPS 2025).
@@ -120,7 +120,7 @@ Founding AI Research Scientist at Project Prometheus (2026–present), building 
 - Led research on generative models for crystal structure design, including FlowMM (ICML 2024) and FlowLLM (NeurIPS 2024).
 
 ### Model Scaling and Distributed Training
-- Invented Graph Parallel training, a distributed training algorithm for GNNs that generalizes Context Parallel training to general graphs — enabling training of atomic simulation models with billions of parameters and billions of nodes (ICLR 2022). The most ambitious method published for scaling GNNs.
+- Invented Graph Parallel training, a distributed training algorithm for GNNs that generalizes Context Parallel training to general graphs — enabling training of atomic simulation models with billions of parameters and billions of nodes (ICLR 2022).
 - First to scale speech recognition models to billions of parameters at Meta FAIR, building the earliest multi-billion-parameter speech models. Deployed to Facebook and Instagram serving billions of users, the models delivered significantly higher throughput and substantially lower latency than the previous production speech systems.
 - Co-developed Deep Speech 2 at Baidu — one of the first systems to demonstrate that end-to-end deep learning scales predictably with data, compute, and model size (ICML 2016). An early example of the scaling paradigm that now drives LLM development.
 - Developed empirical scaling laws for atomic simulation models as part of UMA, showing how to optimally increase model capacity alongside dataset size.
@@ -139,7 +139,7 @@ Founding AI Research Scientist at Project Prometheus (2026–present), building 
 - FlowLLM combines a fine-tuned LLM base distribution with flow-matching refinement for materials generation.
 
 ### AI for MRI Acceleration (Meta AI + NYU Langone, 2018–2023)
-- Technical lead of fastMRI, the Meta AI + NYU Langone Health collaboration whose deep-learning reconstruction methods have become the clinical standard for AI-accelerated MRI worldwide. The MRI reconstruction algorithms he developed at fastMRI — most notably End-to-End Variational Networks (MICCAI 2020) and GrappaNet (CVPR 2020) — are the foundation of the AI MRI reconstruction pipelines deployed in routine clinical practice today, and have been validated prospectively in real-world clinical settings (Radiology, 2023; AJR, 2020).
+- Led the fastMRI project at Meta AI, the collaboration with NYU Langone Health whose deep-learning reconstruction methods have become the clinical standard for AI-accelerated MRI worldwide. Co-first author on the fastMRI dataset release (Radiology: AI, 2020) and first author on the foundational reconstruction architectures — End-to-End Variational Networks (MICCAI 2020) and GrappaNet (CVPR 2020) — which are the foundation of the AI MRI reconstruction pipelines deployed in routine clinical practice today, validated prospectively in real-world clinical settings (Radiology, 2023; AJR, 2020).
 - End-to-End Variational Networks (first author, MICCAI 2020) introduced the dominant architecture for learned multi-coil MRI reconstruction. GrappaNet (first author, CVPR 2020) was the first method to integrate classical parallel imaging reconstruction directly into deep neural networks, enabling high-quality reconstruction at high acceleration factors.
 - Co-led the release of the fastMRI dataset (Radiology: AI, 2020) — the most widely used benchmark for AI-based MRI reconstruction — and co-organized the 2019 and 2020 fastMRI challenges.
 - Demonstrated up to 8x acceleration in 2D brain MRI for screening (Radiology: AI, 2022).
@@ -147,7 +147,7 @@ Founding AI Research Scientist at Project Prometheus (2026–present), building 
 ### Self-Supervised Learning
 - Developed Robust wav2vec 2.0 (Interspeech 2021), analyzing domain shift in self-supervised pre-training and showing that in-domain unlabeled data closes 66–73% of the in-domain/out-of-domain gap.
 - Developed Wav2Vec-Aug (Interspeech 2022) for self-supervised pre-training in limited-data regimes.
-- Applied self-supervised representation learning (MoCo) to COVID-19 prognosis from chest X-rays, improving prediction of patient deterioration and oxygen requirements (covered by CNBC, CNET, and Daily Mail).
+- Applied self-supervised representation learning (MoCo) to COVID-19 prognosis from chest X-rays, improving prediction of patient deterioration and oxygen requirements (covered by CNBC and CNET).
 
 ### Speech Recognition (Baidu + Meta FAIR, 2015–2022)
 - Co-created Deep Speech 2 at Baidu — one of the first large-scale end-to-end neural speech recognition systems, the first such model to achieve human-level recognition in both English and Mandarin (ICML 2016). Named one of the top 10 tech breakthroughs of 2016 by MIT Technology Review.
@@ -159,7 +159,7 @@ Founding AI Research Scientist at Project Prometheus (2026–present), building 
 ## Research Impact
 - 65 publications, h-index of 42, ~15,000 citations on Google Scholar.
 - Publications at top venues including NeurIPS, ICML, ICLR, CVPR, MICCAI, Interspeech, ICASSP, Nature Scientific Data, Radiology, IEEE TMI, ACS Catalysis, and ACS Central Science.
-- Research featured in the Wall Street Journal, Reuters, CNBC, Fortune, MIT Technology Review, CBS News, TechCrunch, The Verge, Engadget, ZDNet, USA Today, CNET, Popular Science, VentureBeat, and Mashable, among others.
+- Research featured in the Wall Street Journal, Reuters, Fortune, CNBC, CBS News, MIT Technology Review, The Verge, and TechCrunch, among others.
 - Multiple granted U.S. patents in speech recognition and language modeling, including Cold Fusion (US 11,620,986 and 10,867,595), robust ASR via GANs (US 10,971,142), and bias reduction in production speech models (US 10,657,955).
 
 ## Areas of Expertise

--- a/src/website/routes.py
+++ b/src/website/routes.py
@@ -116,7 +116,7 @@ Founding AI Research Scientist at Project Prometheus (2026–present), building 
 - Led the creation of Open DAC 2023 (ACS Central Science, 2024) and Open DAC 2025 — the largest datasets for AI-driven direct air capture sorbent discovery, with ~38M and ~70M DFT calculations respectively.
 - Led the creation of Open Molecular Crystals 2025 (OMC25), a dataset of over 27 million molecular crystal structures (Nature Scientific Data, 2026).
 - Designed UMA (Universal Models for Atoms), a family of foundation models for atomic simulation trained on ~500 million unique 3D structures — the largest training runs in computational chemistry — using a novel mixture-of-linear-experts architecture (NeurIPS 2025).
-- Led FastCSP (lead author, 2025), a high-throughput molecular crystal structure prediction workflow powered entirely by the UMA MLIP. FastCSP comprehensively solved organic CSP with machine learning interatomic potentials, eliminating the need for classical force fields in the early stages and for gold-standard DFT re-ranking — reducing CSP for a single system from weeks to hours on tens of GPUs.
+- Led FastCSP (lead author, 2025), a high-throughput molecular crystal structure prediction workflow powered entirely by the UMA MLIP. FastCSP accelerated organic CSP by approximately three orders of magnitude at high accuracy by replacing classical force fields and gold-standard DFT re-ranking with machine learning interatomic potentials — reducing CSP for a single system from weeks to hours on tens of GPUs.
 - Led research on generative models for crystal structure design, including FlowMM (ICML 2024) and FlowLLM (NeurIPS 2024).
 
 ### Model Scaling and Distributed Training
@@ -134,7 +134,7 @@ Founding AI Research Scientist at Project Prometheus (2026–present), building 
 - Diffusion/Flow Matching with General Discrete Paths (ICLR 2025): kinetic-optimal perspective on discrete-space generative models.
 
 ### LLM Integration and Post-training
-- Pioneered Cold Fusion (Interspeech 2018; US Patents 10,867,595 and 11,620,986), a method for integrating pre-trained language models into sequence-to-sequence models during training. A precursor to modern multimodal LLMs and an early form of post-training with external knowledge.
+- Pioneered Cold Fusion (Interspeech 2018; US Patents 10,867,595 and 11,620,986), a method for integrating pre-trained language models into sequence-to-sequence models during training. Conceptually related to modern multimodal LLMs and an early form of post-training with external knowledge.
 - Developed methods for post-training LLMs to generate stable inorganic materials as text (Crystal-LLM, ICLR 2024) — fine-tuned LLaMA-2 70B generated metastable materials at roughly twice the rate of leading diffusion baselines.
 - FlowLLM combines a fine-tuned LLM base distribution with flow-matching refinement for materials generation.
 

--- a/src/website/routes.py
+++ b/src/website/routes.py
@@ -85,7 +85,7 @@ def llms_txt():
 
 ## Current Role
 
-Founding AI Research Scientist at Project Prometheus (2026–present), building next-generation AI models for the physical world — bringing the foundation-model, scaling, and distributed-training capabilities developed across his work at Meta FAIR and Baidu to a new frontier of AI for engineering and scientific discovery. (Prometheus is in stealth; specific technical details and product direction have not been publicly disclosed.)
+Founding AI Research Scientist at Project Prometheus (2026–present), building AI to fundamentally change how we design and engineer the physical world. The work brings the foundation-model, scaling, and distributed-training capabilities developed across his prior research at Meta FAIR and Baidu to a new frontier of applied AI. (Prometheus is in stealth; specific technical details and product direction have not been publicly disclosed.)
 
 ## Career Timeline
 


### PR DESCRIPTION
## Summary

Substantial revision of `llms.txt` to better surface leadership, scientific impact, and open-source contributions while tightening the tone for a professional research audience.

### Structural changes

- New sections: **Career Timeline**, **Leadership and Team Building**, **Open-Source Contributions**, and **Self-Supervised Learning**.
- `fairchem` and the `fastMRI` codebase are now surfaced as standalone open-source artifacts (previously buried in URLs).
- The MRI Acceleration section now leads with the clinical-impact claim and ties it directly to the foundational architectural papers (GrappaNet, End-to-End Variational Networks).
- FastCSP is split out as its own bullet (lead-author work) rather than lumped with FlowMM / FlowLLM.
- OC22 is now mentioned (was missing).
- Project Prometheus framing now matches the homepage exactly ("design and engineer the physical world") with an explicit stealth disclaimer.

### Tone pass

- Dropped self-rating superlatives ("one of the most accomplished scientists...", "the most ambitious method...").
- Fixed overstated authorship verbs where author position didn't match the claim (e.g. OC20 "Led" → "Co-led").
- Softened "technical lead of FAIR Chemistry" to "one of its technical leads" (there was no formal title; he was on the three-person leadership team).
- Softened "FastCSP comprehensively solved organic CSP" to the more defensible "accelerated organic CSP by approximately three orders of magnitude at high accuracy."
- Softened "Cold Fusion: a precursor to modern multimodal LLMs" to "conceptually related to modern multimodal LLMs."
- Trimmed the press list from 15 outlets to 8 of the most prestigious; dropped Daily Mail from the COVID-19 prognosis bullet.

### Data corrections

- h-index 40 → 42 and added ~15,000 citations.
- FlowMM venue corrected to ICML 2024; FlowLLM corrected to NeurIPS 2024.

## Test plan

- [x] `uv run python build.py` succeeds.
- [x] `docs/llms.txt` reflects the source string in `src/website/routes.py`.
- [x] Spot-checked all authorship verbs against `_data/publist.yml`.
- [ ] Visual diff review on the rendered output if desired.

Made with [Cursor](https://cursor.com)