### PR TITLE
Refresh site metadata and add per-page descriptions

### DIFF
--- a/docs/aboutwebsite/index.html
+++ b/docs/aboutwebsite/index.html
@@ -12,19 +12,23 @@
   
   
 
-  <meta name="description" content="Anuroop Sriram — leading AI for Science researcher (65 publications, h-index 40). Founding AI Research Scientist at Project Prometheus. Expert in model scaling (invented Graph Parallel training for GNNs), diffusion/flow matching for science, and post-training LLMs. Previously led AI for Science, fastMRI, and speech research at Meta FAIR. Created Open Catalyst, Open DAC, and OMC25 datasets. Built Deep Speech 2 at Baidu. First to scale speech models to billions of parameters.">
+  <meta name="description" content="About anuroopsriram.com — built with Flask and Frozen-Flask, deployed on GitHub Pages.">
 
   <meta property="og:type" content="website">
   <meta property="og:title" content="About this website - Anuroop Sriram">
-  <meta property="og:description" content="Anuroop Sriram — leading AI for Science researcher (65 publications, h-index 40). Founding AI Research Scientist at Project Prometheus. Expert in model scaling (invented Graph Parallel training for GNNs), diffusion/flow matching for science, and post-training LLMs. Previously led AI for Science, fastMRI, and speech research at Meta FAIR. Created Open Catalyst, Open DAC, and OMC25 datasets. Built Deep Speech 2 at Baidu. First to scale speech models to billions of parameters.">
+  <meta property="og:description" content="About anuroopsriram.com — built with Flask and Frozen-Flask, deployed on GitHub Pages.">
   <meta property="og:url" content="https://anuroopsriram.com/aboutwebsite/">
   <meta property="og:image" content="https://anuroopsriram.com/static/images/teampic/anuroop.webp">
+  <meta property="og:image:width" content="973">
+  <meta property="og:image:height" content="736">
+  <meta property="og:image:alt" content="Photograph of Anuroop Sriram">
   <meta property="og:site_name" content="Anuroop Sriram">
 
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="About this website - Anuroop Sriram">
-  <meta name="twitter:description" content="Anuroop Sriram — leading AI for Science researcher (65 publications, h-index 40). Founding AI Research Scientist at Project Prometheus. Expert in model scaling (invented Graph Parallel training for GNNs), diffusion/flow matching for science, and post-training LLMs. Previously led AI for Science, fastMRI, and speech research at Meta FAIR. Created Open Catalyst, Open DAC, and OMC25 datasets. Built Deep Speech 2 at Baidu. First to scale speech models to billions of parameters.">
+  <meta name="twitter:description" content="About anuroopsriram.com — built with Flask and Frozen-Flask, deployed on GitHub Pages.">
   <meta name="twitter:image" content="https://anuroopsriram.com/static/images/teampic/anuroop.webp">
+  <meta name="twitter:image:alt" content="Photograph of Anuroop Sriram">
   <meta name="twitter:site" content="@anuroopsriram">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/docs/allnews/index.html
+++ b/docs/allnews/index.html
@@ -12,19 +12,23 @@
   
   
 
-  <meta name="description" content="Anuroop Sriram — leading AI for Science researcher (65 publications, h-index 40). Founding AI Research Scientist at Project Prometheus. Expert in model scaling (invented Graph Parallel training for GNNs), diffusion/flow matching for science, and post-training LLMs. Previously led AI for Science, fastMRI, and speech research at Meta FAIR. Created Open Catalyst, Open DAC, and OMC25 datasets. Built Deep Speech 2 at Baidu. First to scale speech models to billions of parameters.">
+  <meta name="description" content="Recent news and updates from Anuroop Sriram, including new papers, dataset releases, conference acceptances, and career milestones.">
 
   <meta property="og:type" content="website">
   <meta property="og:title" content="News - Anuroop Sriram">
-  <meta property="og:description" content="Anuroop Sriram — leading AI for Science researcher (65 publications, h-index 40). Founding AI Research Scientist at Project Prometheus. Expert in model scaling (invented Graph Parallel training for GNNs), diffusion/flow matching for science, and post-training LLMs. Previously led AI for Science, fastMRI, and speech research at Meta FAIR. Created Open Catalyst, Open DAC, and OMC25 datasets. Built Deep Speech 2 at Baidu. First to scale speech models to billions of parameters.">
+  <meta property="og:description" content="Recent news and updates from Anuroop Sriram, including new papers, dataset releases, conference acceptances, and career milestones.">
   <meta property="og:url" content="https://anuroopsriram.com/allnews/">
   <meta property="og:image" content="https://anuroopsriram.com/static/images/teampic/anuroop.webp">
+  <meta property="og:image:width" content="973">
+  <meta property="og:image:height" content="736">
+  <meta property="og:image:alt" content="Photograph of Anuroop Sriram">
   <meta property="og:site_name" content="Anuroop Sriram">
 
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="News - Anuroop Sriram">
-  <meta name="twitter:description" content="Anuroop Sriram — leading AI for Science researcher (65 publications, h-index 40). Founding AI Research Scientist at Project Prometheus. Expert in model scaling (invented Graph Parallel training for GNNs), diffusion/flow matching for science, and post-training LLMs. Previously led AI for Science, fastMRI, and speech research at Meta FAIR. Created Open Catalyst, Open DAC, and OMC25 datasets. Built Deep Speech 2 at Baidu. First to scale speech models to billions of parameters.">
+  <meta name="twitter:description" content="Recent news and updates from Anuroop Sriram, including new papers, dataset releases, conference acceptances, and career milestones.">
   <meta name="twitter:image" content="https://anuroopsriram.com/static/images/teampic/anuroop.webp">
+  <meta name="twitter:image:alt" content="Photograph of Anuroop Sriram">
   <meta name="twitter:site" content="@anuroopsriram">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/docs/datasets/index.html
+++ b/docs/datasets/index.html
@@ -12,19 +12,23 @@
   
   
 
-  <meta name="description" content="Anuroop Sriram — leading AI for Science researcher (65 publications, h-index 40). Founding AI Research Scientist at Project Prometheus. Expert in model scaling (invented Graph Parallel training for GNNs), diffusion/flow matching for science, and post-training LLMs. Previously led AI for Science, fastMRI, and speech research at Meta FAIR. Created Open Catalyst, Open DAC, and OMC25 datasets. Built Deep Speech 2 at Baidu. First to scale speech models to billions of parameters.">
+  <meta name="description" content="Open scientific datasets created or co-created by Anuroop Sriram, including Open Catalyst (OC20, OC22), Open DAC (ODAC23, ODAC25), Open Molecular Crystals (OMC25), fastMRI, and Multilingual LibriSpeech (MLS).">
 
   <meta property="og:type" content="website">
   <meta property="og:title" content="Datasets - Anuroop Sriram">
-  <meta property="og:description" content="Anuroop Sriram — leading AI for Science researcher (65 publications, h-index 40). Founding AI Research Scientist at Project Prometheus. Expert in model scaling (invented Graph Parallel training for GNNs), diffusion/flow matching for science, and post-training LLMs. Previously led AI for Science, fastMRI, and speech research at Meta FAIR. Created Open Catalyst, Open DAC, and OMC25 datasets. Built Deep Speech 2 at Baidu. First to scale speech models to billions of parameters.">
+  <meta property="og:description" content="Open scientific datasets created or co-created by Anuroop Sriram, including Open Catalyst (OC20, OC22), Open DAC (ODAC23, ODAC25), Open Molecular Crystals (OMC25), fastMRI, and Multilingual LibriSpeech (MLS).">
   <meta property="og:url" content="https://anuroopsriram.com/datasets/">
   <meta property="og:image" content="https://anuroopsriram.com/static/images/teampic/anuroop.webp">
+  <meta property="og:image:width" content="973">
+  <meta property="og:image:height" content="736">
+  <meta property="og:image:alt" content="Photograph of Anuroop Sriram">
   <meta property="og:site_name" content="Anuroop Sriram">
 
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="Datasets - Anuroop Sriram">
-  <meta name="twitter:description" content="Anuroop Sriram — leading AI for Science researcher (65 publications, h-index 40). Founding AI Research Scientist at Project Prometheus. Expert in model scaling (invented Graph Parallel training for GNNs), diffusion/flow matching for science, and post-training LLMs. Previously led AI for Science, fastMRI, and speech research at Meta FAIR. Created Open Catalyst, Open DAC, and OMC25 datasets. Built Deep Speech 2 at Baidu. First to scale speech models to billions of parameters.">
+  <meta name="twitter:description" content="Open scientific datasets created or co-created by Anuroop Sriram, including Open Catalyst (OC20, OC22), Open DAC (ODAC23, ODAC25), Open Molecular Crystals (OMC25), fastMRI, and Multilingual LibriSpeech (MLS).">
   <meta name="twitter:image" content="https://anuroopsriram.com/static/images/teampic/anuroop.webp">
+  <meta name="twitter:image:alt" content="Photograph of Anuroop Sriram">
   <meta name="twitter:site" content="@anuroopsriram">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,19 +12,23 @@
   
   
 
-  <meta name="description" content="Anuroop Sriram — leading AI for Science researcher (65 publications, h-index 40). Founding AI Research Scientist at Project Prometheus. Expert in model scaling (invented Graph Parallel training for GNNs), diffusion/flow matching for science, and post-training LLMs. Previously led AI for Science, fastMRI, and speech research at Meta FAIR. Created Open Catalyst, Open DAC, and OMC25 datasets. Built Deep Speech 2 at Baidu. First to scale speech models to billions of parameters.">
+  <meta name="description" content="Anuroop Sriram — leading AI for Science researcher (65 publications, h-index 42, ~15,000 citations). Founding AI Research Scientist at Project Prometheus. Expert in foundation models for atomic simulation (UMA, FastCSP), model scaling (invented Graph Parallel training for GNNs), diffusion and flow matching for science, and post-training LLMs. Previously a technical lead of FAIR Chemistry at Meta and Research Manager of FAIR Speech. Co-led the Open Catalyst, Open DAC, OMC25, and Multilingual LibriSpeech datasets. Led the fastMRI project at Meta AI. Co-created Deep Speech 2 at Baidu.">
 
   <meta property="og:type" content="website">
   <meta property="og:title" content="Anuroop Sriram">
-  <meta property="og:description" content="Anuroop Sriram — leading AI for Science researcher (65 publications, h-index 40). Founding AI Research Scientist at Project Prometheus. Expert in model scaling (invented Graph Parallel training for GNNs), diffusion/flow matching for science, and post-training LLMs. Previously led AI for Science, fastMRI, and speech research at Meta FAIR. Created Open Catalyst, Open DAC, and OMC25 datasets. Built Deep Speech 2 at Baidu. First to scale speech models to billions of parameters.">
+  <meta property="og:description" content="Anuroop Sriram — leading AI for Science researcher (65 publications, h-index 42, ~15,000 citations). Founding AI Research Scientist at Project Prometheus. Expert in foundation models for atomic simulation (UMA, FastCSP), model scaling (invented Graph Parallel training for GNNs), diffusion and flow matching for science, and post-training LLMs. Previously a technical lead of FAIR Chemistry at Meta and Research Manager of FAIR Speech. Co-led the Open Catalyst, Open DAC, OMC25, and Multilingual LibriSpeech datasets. Led the fastMRI project at Meta AI. Co-created Deep Speech 2 at Baidu.">
   <meta property="og:url" content="https://anuroopsriram.com/">
   <meta property="og:image" content="https://anuroopsriram.com/static/images/teampic/anuroop.webp">
+  <meta property="og:image:width" content="973">
+  <meta property="og:image:height" content="736">
+  <meta property="og:image:alt" content="Photograph of Anuroop Sriram">
   <meta property="og:site_name" content="Anuroop Sriram">
 
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="Anuroop Sriram">
-  <meta name="twitter:description" content="Anuroop Sriram — leading AI for Science researcher (65 publications, h-index 40). Founding AI Research Scientist at Project Prometheus. Expert in model scaling (invented Graph Parallel training for GNNs), diffusion/flow matching for science, and post-training LLMs. Previously led AI for Science, fastMRI, and speech research at Meta FAIR. Created Open Catalyst, Open DAC, and OMC25 datasets. Built Deep Speech 2 at Baidu. First to scale speech models to billions of parameters.">
+  <meta name="twitter:description" content="Anuroop Sriram — leading AI for Science researcher (65 publications, h-index 42, ~15,000 citations). Founding AI Research Scientist at Project Prometheus. Expert in foundation models for atomic simulation (UMA, FastCSP), model scaling (invented Graph Parallel training for GNNs), diffusion and flow matching for science, and post-training LLMs. Previously a technical lead of FAIR Chemistry at Meta and Research Manager of FAIR Speech. Co-led the Open Catalyst, Open DAC, OMC25, and Multilingual LibriSpeech datasets. Led the fastMRI project at Meta AI. Co-created Deep Speech 2 at Baidu.">
   <meta name="twitter:image" content="https://anuroopsriram.com/static/images/teampic/anuroop.webp">
+  <meta name="twitter:image:alt" content="Photograph of Anuroop Sriram">
   <meta name="twitter:site" content="@anuroopsriram">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -89,21 +93,23 @@
     "name": "United States"
   },
   "jobTitle": "Founding AI Research Scientist",
-  "description": "Anuroop Sriram is a leading AI for Science researcher (65 publications, h-index 40) and Founding AI Research Scientist at Project Prometheus. He pioneered the use of AI to accelerate materials discovery, MRI scanning, and speech recognition at scale. He invented Graph Parallel training for scaling GNNs to billions of parameters and was the first to scale speech models to billions of parameters. At Meta FAIR, he led the creation of the Open Catalyst, Open DAC, and OMC25 datasets — among the largest open scientific datasets in AI for materials science. He led fastMRI, whose AI-accelerated methods became the clinical standard for MRI worldwide. He co-created Deep Speech 2, one of the first end-to-end neural speech recognition systems. He is an expert in diffusion models and flow matching for scientific applications, and in post-training LLMs for science.",
+  "description": "Anuroop Sriram is a leading AI for Science researcher (65 publications, h-index 42, ~15,000 citations) and Founding AI Research Scientist at Project Prometheus. He has applied AI to accelerate materials discovery, MRI scanning, and speech recognition at scale. He invented Graph Parallel training for scaling GNNs to billions of parameters and was the first to scale speech models to billions of parameters at Meta FAIR. As a technical lead of FAIR Chemistry, he co-led the creation of the Open Catalyst, Open DAC, and OMC25 datasets, the UMA family of foundation models for atomic simulation, and FastCSP for accelerated crystal structure prediction. He led the fastMRI project at Meta AI, the collaboration with NYU Langone Health whose deep-learning reconstruction methods became the clinical standard for AI-accelerated MRI worldwide. He co-created Deep Speech 2 at Baidu, one of the first end-to-end neural speech recognition systems. He is an expert in diffusion models and flow matching for scientific applications, and in post-training LLMs for science.",
   "knowsAbout": [
     "AI for Science",
-    "Model Scaling and Large-Scale Training",
+    "Foundation Models for Atomic Simulation",
+    "Machine Learning Interatomic Potentials",
+    "Model Scaling and Large-Scale Distributed Training",
     "Graph Parallel Training for GNNs",
     "Diffusion Models and Flow Matching",
     "Post-training and Fine-tuning LLMs",
-    "Machine Learning Interatomic Potentials",
     "Materials Discovery",
     "Crystal Structure Prediction",
     "Generative Models for Molecules and Materials",
-    "MRI Acceleration",
-    "Speech Recognition",
-    "Self-Supervised Learning",
-    "Scientific Benchmarks and Datasets"
+    "MRI Acceleration with Deep Learning",
+    "End-to-End and Self-Supervised Speech Recognition",
+    "Massively Multilingual Modeling",
+    "Scientific Benchmarks and Datasets",
+    "Research Leadership and Team Building"
   ],
   "worksFor": {
     "@type": "Organization",

--- a/docs/publications/index.html
+++ b/docs/publications/index.html
@@ -12,19 +12,23 @@
   
   
 
-  <meta name="description" content="Anuroop Sriram — leading AI for Science researcher (65 publications, h-index 40). Founding AI Research Scientist at Project Prometheus. Expert in model scaling (invented Graph Parallel training for GNNs), diffusion/flow matching for science, and post-training LLMs. Previously led AI for Science, fastMRI, and speech research at Meta FAIR. Created Open Catalyst, Open DAC, and OMC25 datasets. Built Deep Speech 2 at Baidu. First to scale speech models to billions of parameters.">
+  <meta name="description" content="65 publications by Anuroop Sriram covering AI for Science, model scaling, diffusion and flow matching, MRI acceleration, and speech recognition. Includes work on UMA, Open Catalyst, FlowMM, FlowLLM, FastCSP, GrappaNet, End-to-End Variational Networks, Deep Speech 2, and Multilingual LibriSpeech.">
 
   <meta property="og:type" content="website">
   <meta property="og:title" content="Publications - Anuroop Sriram">
-  <meta property="og:description" content="Anuroop Sriram — leading AI for Science researcher (65 publications, h-index 40). Founding AI Research Scientist at Project Prometheus. Expert in model scaling (invented Graph Parallel training for GNNs), diffusion/flow matching for science, and post-training LLMs. Previously led AI for Science, fastMRI, and speech research at Meta FAIR. Created Open Catalyst, Open DAC, and OMC25 datasets. Built Deep Speech 2 at Baidu. First to scale speech models to billions of parameters.">
+  <meta property="og:description" content="65 publications by Anuroop Sriram covering AI for Science, model scaling, diffusion and flow matching, MRI acceleration, and speech recognition. Includes work on UMA, Open Catalyst, FlowMM, FlowLLM, FastCSP, GrappaNet, End-to-End Variational Networks, Deep Speech 2, and Multilingual LibriSpeech.">
   <meta property="og:url" content="https://anuroopsriram.com/publications/">
   <meta property="og:image" content="https://anuroopsriram.com/static/images/teampic/anuroop.webp">
+  <meta property="og:image:width" content="973">
+  <meta property="og:image:height" content="736">
+  <meta property="og:image:alt" content="Photograph of Anuroop Sriram">
   <meta property="og:site_name" content="Anuroop Sriram">
 
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="Publications - Anuroop Sriram">
-  <meta name="twitter:description" content="Anuroop Sriram — leading AI for Science researcher (65 publications, h-index 40). Founding AI Research Scientist at Project Prometheus. Expert in model scaling (invented Graph Parallel training for GNNs), diffusion/flow matching for science, and post-training LLMs. Previously led AI for Science, fastMRI, and speech research at Meta FAIR. Created Open Catalyst, Open DAC, and OMC25 datasets. Built Deep Speech 2 at Baidu. First to scale speech models to billions of parameters.">
+  <meta name="twitter:description" content="65 publications by Anuroop Sriram covering AI for Science, model scaling, diffusion and flow matching, MRI acceleration, and speech recognition. Includes work on UMA, Open Catalyst, FlowMM, FlowLLM, FastCSP, GrappaNet, End-to-End Variational Networks, Deep Speech 2, and Multilingual LibriSpeech.">
   <meta name="twitter:image" content="https://anuroopsriram.com/static/images/teampic/anuroop.webp">
+  <meta name="twitter:image:alt" content="Photograph of Anuroop Sriram">
   <meta name="twitter:site" content="@anuroopsriram">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -2,3 +2,7 @@ User-agent: *
 Allow: /
 
 Sitemap: https://anuroopsriram.com/sitemap.xml
+
+# LLM-friendly summaries (for AI crawlers and tools):
+# https://anuroopsriram.com/llms.txt
+# https://anuroopsriram.com/llms-full.txt

--- a/src/website/config.py
+++ b/src/website/config.py
@@ -9,7 +9,7 @@ class Config:
     
     # Site configuration
     SITE_TITLE = 'Anuroop Sriram'
-    SITE_DESCRIPTION = 'Anuroop Sriram — leading AI for Science researcher (65 publications, h-index 40). Founding AI Research Scientist at Project Prometheus. Expert in model scaling (invented Graph Parallel training for GNNs), diffusion/flow matching for science, and post-training LLMs. Previously led AI for Science, fastMRI, and speech research at Meta FAIR. Created Open Catalyst, Open DAC, and OMC25 datasets. Built Deep Speech 2 at Baidu. First to scale speech models to billions of parameters.'
+    SITE_DESCRIPTION = 'Anuroop Sriram — leading AI for Science researcher (65 publications, h-index 42, ~15,000 citations). Founding AI Research Scientist at Project Prometheus. Expert in foundation models for atomic simulation (UMA, FastCSP), model scaling (invented Graph Parallel training for GNNs), diffusion and flow matching for science, and post-training LLMs. Previously a technical lead of FAIR Chemistry at Meta and Research Manager of FAIR Speech. Co-led the Open Catalyst, Open DAC, OMC25, and Multilingual LibriSpeech datasets. Led the fastMRI project at Meta AI. Co-created Deep Speech 2 at Baidu.'
     SITE_BASEURL = ''
     SITE_URL = 'https://anuroopsriram.com'
     GOOGLE_ANALYTICS = 'G-H1K2L7JV60'

--- a/src/website/routes.py
+++ b/src/website/routes.py
@@ -16,29 +16,47 @@ def home():
 
 @main.route('/publications/')
 def publications():
+    description = (
+        '65 publications by Anuroop Sriram covering AI for Science, model scaling, '
+        'diffusion and flow matching, MRI acceleration, and speech recognition. '
+        'Includes work on UMA, Open Catalyst, FlowMM, FlowLLM, FastCSP, GrappaNet, '
+        'End-to-End Variational Networks, Deep Speech 2, and Multilingual LibriSpeech.'
+    )
     return render_template('pages/publications.html',
-                         page={'title': 'Publications', 'permalink': '/publications/'},
+                         page={'title': 'Publications', 'permalink': '/publications/', 'description': description},
                          active_page='publications')
 
 
 @main.route('/datasets/')
 def datasets():
+    description = (
+        'Open scientific datasets created or co-created by Anuroop Sriram, including '
+        'Open Catalyst (OC20, OC22), Open DAC (ODAC23, ODAC25), Open Molecular Crystals '
+        '(OMC25), fastMRI, and Multilingual LibriSpeech (MLS).'
+    )
     return render_template('pages/datasets.html',
-                         page={'title': 'Datasets', 'permalink': '/datasets/'},
+                         page={'title': 'Datasets', 'permalink': '/datasets/', 'description': description},
                          active_page='datasets')
 
 
 @main.route('/allnews/')
 def allnews():
+    description = (
+        'Recent news and updates from Anuroop Sriram, including new papers, dataset releases, '
+        'conference acceptances, and career milestones.'
+    )
     return render_template('pages/allnews.html',
-                         page={'title': 'News', 'permalink': '/allnews/'},
+                         page={'title': 'News', 'permalink': '/allnews/', 'description': description},
                          active_page='news')
 
 
 @main.route('/aboutwebsite/')
 def aboutwebsite():
+    description = (
+        'About anuroopsriram.com — built with Flask and Frozen-Flask, deployed on GitHub Pages.'
+    )
     return render_template('pages/aboutwebsite.html',
-                         page={'title': 'About this website', 'permalink': '/aboutwebsite/'},
+                         page={'title': 'About this website', 'permalink': '/aboutwebsite/', 'description': description},
                          active_page='about')
 
 
@@ -71,7 +89,16 @@ def sitemap():
 @main.route('/robots.txt')
 def robots():
     site_url = current_app.config.get('SITE_URL', 'https://anuroopsriram.com')
-    txt = f'User-agent: *\nAllow: /\n\nSitemap: {site_url}/sitemap.xml\n'
+    txt = (
+        'User-agent: *\n'
+        'Allow: /\n'
+        '\n'
+        f'Sitemap: {site_url}/sitemap.xml\n'
+        '\n'
+        '# LLM-friendly summaries (for AI crawlers and tools):\n'
+        f'# {site_url}/llms.txt\n'
+        f'# {site_url}/llms-full.txt\n'
+    )
     resp = make_response(txt)
     resp.headers['Content-Type'] = 'text/plain'
     return resp

--- a/templates/includes/head.html
+++ b/templates/includes/head.html
@@ -8,7 +8,7 @@
   {% endif %}
 
   {% set meta_title = page.title ~ ' - ' ~ site.title if page.title else site.title %}
-  {% set meta_description = site.description %}
+  {% set meta_description = page.description if page.description else site.description %}
   {% set meta_url = site.url ~ site.baseurl ~ page.permalink %}
   {% set meta_image = site.url ~ '/static/images/teampic/anuroop.webp' %}
 
@@ -19,12 +19,16 @@
   <meta property="og:description" content="{{ meta_description }}">
   <meta property="og:url" content="{{ meta_url }}">
   <meta property="og:image" content="{{ meta_image }}">
+  <meta property="og:image:width" content="973">
+  <meta property="og:image:height" content="736">
+  <meta property="og:image:alt" content="Photograph of Anuroop Sriram">
   <meta property="og:site_name" content="{{ site.title }}">
 
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="{{ meta_title }}">
   <meta name="twitter:description" content="{{ meta_description }}">
   <meta name="twitter:image" content="{{ meta_image }}">
+  <meta name="twitter:image:alt" content="Photograph of Anuroop Sriram">
   <meta name="twitter:site" content="@anuroopsriram">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -15,21 +15,23 @@
     "name": "United States"
   },
   "jobTitle": "Founding AI Research Scientist",
-  "description": "Anuroop Sriram is a leading AI for Science researcher (65 publications, h-index 40) and Founding AI Research Scientist at Project Prometheus. He pioneered the use of AI to accelerate materials discovery, MRI scanning, and speech recognition at scale. He invented Graph Parallel training for scaling GNNs to billions of parameters and was the first to scale speech models to billions of parameters. At Meta FAIR, he led the creation of the Open Catalyst, Open DAC, and OMC25 datasets — among the largest open scientific datasets in AI for materials science. He led fastMRI, whose AI-accelerated methods became the clinical standard for MRI worldwide. He co-created Deep Speech 2, one of the first end-to-end neural speech recognition systems. He is an expert in diffusion models and flow matching for scientific applications, and in post-training LLMs for science.",
+  "description": "Anuroop Sriram is a leading AI for Science researcher (65 publications, h-index 42, ~15,000 citations) and Founding AI Research Scientist at Project Prometheus. He has applied AI to accelerate materials discovery, MRI scanning, and speech recognition at scale. He invented Graph Parallel training for scaling GNNs to billions of parameters and was the first to scale speech models to billions of parameters at Meta FAIR. As a technical lead of FAIR Chemistry, he co-led the creation of the Open Catalyst, Open DAC, and OMC25 datasets, the UMA family of foundation models for atomic simulation, and FastCSP for accelerated crystal structure prediction. He led the fastMRI project at Meta AI, the collaboration with NYU Langone Health whose deep-learning reconstruction methods became the clinical standard for AI-accelerated MRI worldwide. He co-created Deep Speech 2 at Baidu, one of the first end-to-end neural speech recognition systems. He is an expert in diffusion models and flow matching for scientific applications, and in post-training LLMs for science.",
   "knowsAbout": [
     "AI for Science",
-    "Model Scaling and Large-Scale Training",
+    "Foundation Models for Atomic Simulation",
+    "Machine Learning Interatomic Potentials",
+    "Model Scaling and Large-Scale Distributed Training",
     "Graph Parallel Training for GNNs",
     "Diffusion Models and Flow Matching",
     "Post-training and Fine-tuning LLMs",
-    "Machine Learning Interatomic Potentials",
     "Materials Discovery",
     "Crystal Structure Prediction",
     "Generative Models for Molecules and Materials",
-    "MRI Acceleration",
-    "Speech Recognition",
-    "Self-Supervised Learning",
-    "Scientific Benchmarks and Datasets"
+    "MRI Acceleration with Deep Learning",
+    "End-to-End and Self-Supervised Speech Recognition",
+    "Massively Multilingual Modeling",
+    "Scientific Benchmarks and Datasets",
+    "Research Leadership and Team Building"
   ],
   "worksFor": {
     "@type": "Organization",


### PR DESCRIPTION
## Summary

Updates the machine-readable surface of the site to match the just-merged llms.txt and to give each page its own meta description for better SEO.

- Bump h-index 40 -> 42 and add ~15,000 citations in `SITE_DESCRIPTION` and home page JSON-LD `description`.
- Surface UMA, FastCSP, and OMC25; soften "He led fastMRI" -> "Led the fastMRI project at Meta AI" to match the new llms.txt language.
- Expand the home page JSON-LD `knowsAbout` (foundation models for atomic simulation, massively multilingual modeling, research leadership).
- Per-page meta descriptions: `head.html` now uses `page.description` when set, with tailored fallbacks for `/publications/`, `/datasets/`, `/allnews/`, `/aboutwebsite/`.
- Add `og:image:width` (973), `og:image:height` (736), `og:image:alt`, and `twitter:image:alt`.
- Add LLM hint URLs (`llms.txt`, `llms-full.txt`) as comments in `robots.txt`.

## Test plan

- [x] `uv run python build.py` succeeds.
- [x] Spot-checked rendered `<meta name="description">` differs per page in `docs/`.
- [x] Spot-checked `og:image:width` / `og:image:height` appear in built HTML.
- [x] Spot-checked `robots.txt` includes new hint lines.


Made with [Cursor](https://cursor.com)